### PR TITLE
Ktrack command: renamed to "ktrack"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
-
-
+### Changed
+- renamed ktrack_command to ktrack
+### Added
 ## 0.0.1 - 2017-07-24
 ### Added
 - This CHANGELOG file to hopefully serve as an evolving example

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     entry_points={
         'console_scripts': [
             'interactive_api = scripts.interactive_api:main',
-            'ktrack_command = scripts.ktrack_command:main',
+            'ktrack = scripts.ktrack_command:main',
         ]
     }
 )


### PR DESCRIPTION
Renamed "ktrack_command" to "ktrack", so its easier to read and type